### PR TITLE
Remove corporate sponsorship option from template

### DIFF
--- a/.github/ISSUE_TEMPLATE/sponsorship.yml
+++ b/.github/ISSUE_TEMPLATE/sponsorship.yml
@@ -19,7 +19,6 @@ body:
       options:
         - GitHub Sponsors (monthly/one-time)
         - Buy Me A Coffee
-        - Corporate sponsorship
         - Other (please describe below)
     validations:
       required: true


### PR DESCRIPTION
This pull request makes a minor update to the sponsorship issue template by removing the "Corporate sponsorship" option from the list of available sponsorship types.