### PR TITLE
Add assignee to collaboration issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/collaboration.yml
+++ b/.github/ISSUE_TEMPLATE/collaboration.yml
@@ -2,7 +2,7 @@ name: 🤝 Collaboration / Partnership
 description: Reach out to collaborate on IT automation, security, or identity projects
 title: "[Collaboration]: "
 labels: ["🤝 collaboration"]
-assigne: callmesukhi
+assignees: callmesukhi
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/collaboration.yml
+++ b/.github/ISSUE_TEMPLATE/collaboration.yml
@@ -2,6 +2,7 @@ name: 🤝 Collaboration / Partnership
 description: Reach out to collaborate on IT automation, security, or identity projects
 title: "[Collaboration]: "
 labels: ["🤝 collaboration"]
+assigne: callmesukhi
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -2,6 +2,7 @@ name: 💬 Question / Discussion
 description: Ask a question or start a discussion about the projects and work
 title: "[Question]: "
 labels: ["💬 question"]
+assignees: callmesukhi
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/sponsorship.yml
+++ b/.github/ISSUE_TEMPLATE/sponsorship.yml
@@ -2,6 +2,7 @@ name: ❤️ Sponsorship / Support
 description: Inquire about sponsoring or supporting the work
 title: "[Sponsorship]: "
 labels: ["❤️ sponsorship"]
+assignees: callmesukhi
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
This pull request updates the GitHub issue templates to automatically assign the user `callmesukhi` to new issues for collaboration, questions, and sponsorship. This ensures that relevant issues are promptly directed to the appropriate person for follow-up.